### PR TITLE
Fix "Directions" link

### DIFF
--- a/examples/gcm/js/cnMapFilter.js
+++ b/examples/gcm/js/cnMapFilter.js
@@ -68,7 +68,7 @@
 		return this.validCoords ?  this.lt + "," + this.lg : '';
 	};
 	EventClass.prototype.getDirectionsUrlStr = function(){
-		return 'http://maps.google.com/maps?f=d&q=' + this.addrToGoogle.replace(/ /g, '+').replace(/"/g, '%22');
+		return 'http://maps.google.com/maps?q=' + this.addrToGoogle.replace(/ /g, '+').replace(/"/g, '%22');
 	};
 	EventClass.prototype.insideCurMap = function(mapbox){
 		return this.validCoords ? mapbox.contains(new google.maps.LatLng(this.lt, this.lg)) : false;


### PR DESCRIPTION
Examples:
(without this fix)
http://maps.google.com/maps?f=d&q=7502+East+83rd+Street,+Tulsa,+OK+74133,+USA redirects to https://www.google.com/maps/preview?f=d&q=7502+East+83rd+Street,+Tulsa,+OK+74133,+USA which then redirects to https://www.google.com/maps/dir///@36.2928559,-95.8048779,12z/data=!3m1!4b1!4m3!4m2!1m0!1m0

(with this fix)
http://maps.google.com/maps?q=7502+East+83rd+Street,+Tulsa,+OK+74133,+USA redirects to https://www.google.com/maps/preview?q=7502+East+83rd+Street,+Tulsa,+OK+74133,+USA and works as intended
